### PR TITLE
PR 3: API Edge Cases & Gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ This script generates realistic mock data in Klaviyo to power reporting demos, t
 
 ## API Version
 
+> ⚠️ **IMPORTANT:** All API requests **must** include the `Klaviyo-Api-Version: 2025-04-15` header
+
 - All scripts use Klaviyo API revision **2025-04-15**
 - See [API Usage Guidelines](docs/api_usage.md) for important information about API versioning and edge cases
+- Missing this header is a common cause of unexpected API behavior and errors
 - TODO: Make API revision an environment variable to simplify future updates
 
 ## Installation

--- a/docs/POC_plan.md
+++ b/docs/POC_plan.md
@@ -66,14 +66,16 @@ LOOKER_REPORT_URL=https://datastudio.google.com/reporting/<REPORT_ID>
   { "data": { "type": "campaign-send-job", "relationships": { "campaign": { "data": { "type": "campaign", "id": "<CAMPAIGN_ID>" } } } } }
   ```
 
+- **Relationships Object Requirement:** ⚠️ The `relationships` object is **required** in many API payloads and is a common source of errors. Always include the full relationships structure as shown in the examples above, even if it seems redundant with information in the attributes. Omitting this structure will result in 400 Bad Request errors that can be difficult to debug.
+
 - **Metric Aggregates:** Numeric `metric_id` is required. Look up IDs via `GET /api/metrics/?filter=equals(name,'<Metric Name>')` and cache results in `.metric_ids.json`.
 
 - **Event Injection:** Only custom events can be injected reliably and will not appear in aggregate metrics. **Option B is load-test only**; default to Option A for POC metrics.
 
 - **Preview vs Full Send:** A preview send logs only under “Email Preview Send.” For aggregate metrics, perform a **full send** (Send Now) to a list (size=1 is fine) and then pause the campaign.
-- **Date Handling:** Always use ISO 8601 UTC format for date parameters (e.g., `2025-05-01` for May 1st, 2025). Explicitly use UTC in your code: `datetime.datetime.utcnow()` instead of `datetime.datetime.now()`.
+- **Date Handling:** Always use ISO 8601 UTC format for date parameters (e.g., `2025-05-01` for May 1st, 2025). Explicitly use UTC in your code: `datetime.datetime.now(UTC)` instead of `datetime.datetime.now()`. Note that `datetime.datetime.utcnow()` is deprecated in newer Python versions.
 
-- **API Version Consistency:** Always include the `Klaviyo-Api-Version: 2025-04-15` header in all API requests to ensure consistent behavior, especially for newer endpoints.
+- **API Version Consistency:** ⚠️ Always include the `Klaviyo-Api-Version: 2025-04-15` header in **all** API requests to ensure consistent behavior, especially for newer endpoints. Missing this header is a common cause of unexpected API behavior and errors.
 ---
 
 ### 4. Profile Creation (`seed_profiles.py`)

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -123,7 +123,10 @@ def get_metric_id(name, force_refresh=False):
                 pass  # Cache file is invalid, continue to API lookup
     
     # Lookup via API
-    headers = {"Authorization": f"Klaviyo-API-Key {os.environ['KLAVIYO_API_KEY']}"}
+    headers = {
+        "Authorization": f"Klaviyo-API-Key {os.environ['KLAVIYO_API_KEY']}",
+        "Klaviyo-Api-Version": "2025-04-15"
+    }
     response = requests.get(
         "https://a.klaviyo.com/api/metrics/", 
         headers=headers,


### PR DESCRIPTION
Implements PR #3 from the [GitHub PR Plan](docs/GITHUB_PR_PLAN.md).

This PR enhances the API documentation:

- u2705 Added warning about relationships object requirement to API Edge Cases & Gotchas section in POC_plan.md
- u2705 Updated get_metric_id() example in api_usage.md to include Klaviyo-Api-Version header
- u2705 Added prominent warning about API version header requirement in README.md
- u2705 Updated date handling documentation to use datetime.now(UTC) instead of utcnow() which is deprecated

## Validation
1. docs/api_usage.md exists with header docs
2. README links to docs/api_usage.md

## Evidence
All documentation has been updated with consistent information about API version headers and relationship objects.