### PR TITLE
Add Git Workflow Documentation and Branch Cleanup Script

### DIFF
--- a/docs/GITHUB_PR_PLAN.md
+++ b/docs/GITHUB_PR_PLAN.md
@@ -56,20 +56,20 @@ This PR adds API edge case documentation and implements version header handling.
 
 ---
 
-## PR 3: API Edge Cases & Gotchas
+## PR 3: API Edge Cases & Gotchas ✅
 **Branch:** feature/api-edge-cases
-- [ ] Add **API Edge Cases & Gotchas** section to `POC_plan.md`.
-- [ ] Enrich payloads with `relationships.template` and version header.
-- [ ] Document `Klaviyo-Api-Version` header in `docs/api_usage.md` and link from README.
+- [x] Add **API Edge Cases & Gotchas** section to `POC_plan.md`.
+- [x] Enrich payloads with `relationships.template` and version header.
+- [x] Document `Klaviyo-Api-Version` header in `docs/api_usage.md` and link from README.
 
 **Validation:**
 1. `docs/api_usage.md` exists with header docs.
 2. README links to `docs/api_usage.md`.
 
 **Merge when these checkboxes are green:**
-- [ ] Documentation validated.
+- [x] Documentation validated.
 
-**Evidence:** Paste PR diff or screenshot here.
+**Evidence:** PR #4 merged on May 2, 2025. Added API usage guidelines document with version header documentation and updated POC_plan.md with additional API edge cases.
 
 ---
 

--- a/docs/git_workflow.md
+++ b/docs/git_workflow.md
@@ -1,0 +1,67 @@
+# Git Workflow Guidelines
+
+## Branch Management
+
+### Creating a Branch
+
+1. Always create branches from the latest `main`:
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b feature/your-feature-name
+   ```
+
+### Working on a Branch
+
+1. Commit your changes frequently with meaningful commit messages:
+   ```bash
+   git add .
+   git commit -m "Descriptive message about what changed"
+   ```
+
+2. Push your branch to remote to save your work:
+   ```bash
+   git push -u origin feature/your-feature-name
+   ```
+
+### Creating a Pull Request
+
+1. Push your final changes to the remote branch:
+   ```bash
+   git add .
+   git commit -m "Final changes for PR"
+   git push origin feature/your-feature-name
+   ```
+
+2. Create a Pull Request on GitHub with a clear title and description.
+
+### Merging a Pull Request
+
+1. **Important**: When merging a PR on GitHub, use the "Squash and merge" option.
+   - This creates a clean, single commit on the main branch
+   - This ensures the "Delete branch on merge" option works correctly
+
+2. After merging, the branch should be automatically deleted on GitHub.
+
+### Cleaning Up Branches
+
+Periodically run the cleanup script to remove merged branches:
+
+```bash
+./scripts/cleanup_branches.sh
+```
+
+## Repository Settings
+
+The repository has the following settings enabled:
+
+- **Delete branch on merge**: Automatically deletes the branch after a PR is merged
+- **Squash merging**: Combines all commits into a single commit when merging
+
+## Troubleshooting
+
+If branches are not being automatically deleted after merging:
+
+1. Ensure you're using the "Squash and merge" option when merging PRs
+2. Check that the "Delete branch on merge" option is enabled in the repository settings
+3. Run the cleanup script to manually delete merged branches

--- a/scripts/cleanup_branches.sh
+++ b/scripts/cleanup_branches.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Script to clean up merged branches
+
+# Get the current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Fetch the latest from remote
+git fetch --prune
+
+# Get list of merged branches (excluding main and current branch)
+MERGED_BRANCHES=$(git branch --merged main | grep -v "^\*" | grep -v "main" | tr -d ' ')
+
+echo "The following branches have been merged into main and will be deleted:"
+echo "$MERGED_BRANCHES"
+echo ""
+
+# Confirm before proceeding
+read -p "Do you want to proceed with deletion? (y/n): " CONFIRM
+if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+    echo "Operation cancelled."
+    exit 0
+fi
+
+# Delete local branches
+for BRANCH in $MERGED_BRANCHES; do
+    echo "Deleting local branch: $BRANCH"
+    git branch -d "$BRANCH"
+done
+
+# Delete remote branches
+for BRANCH in $MERGED_BRANCHES; do
+    echo "Deleting remote branch: $BRANCH"
+    git push origin --delete "$BRANCH"
+done
+
+echo ""
+echo "Branch cleanup completed."


### PR DESCRIPTION
## Description
This PR addresses the issue with branches not being automatically deleted after merging by:

1. Adding a comprehensive Git workflow documentation that explains:
   - How to create and work with branches
   - The proper way to merge PRs (using 'Squash and merge')
   - How to ensure branches are deleted after merging

2. Creating a branch cleanup script (scripts/cleanup_branches.sh) that:
   - Identifies branches that have been merged to main
   - Safely deletes them both locally and remotely
   - Includes confirmation prompts for safety

## Why This Matters
- Keeps the repository clean and organized
- Prevents confusion from stale branches
- Establishes consistent practices for all developers

## How to Test
1. Review the documentation for clarity and completeness
2. Run the cleanup script to verify it correctly identifies and removes merged branches

## Next Steps
1. Ensure the 'Delete branch on merge' setting is enabled in the GitHub repository settings
2. Share the new workflow documentation with all team members