### PR TITLE
Fix PR numbering in PR plan

### DIFF
--- a/docs/GITHUB_PR_PLAN.md
+++ b/docs/GITHUB_PR_PLAN.md
@@ -119,7 +119,7 @@ This PR adds API edge case documentation and implements version header handling.
 **Merge when these checkboxes are green:**
 - [x] Idempotency validated.
 
-**Evidence:** PR #18 merged on May 2, 2025. Added proper handling of HTTP 201 and 202 status codes for idempotent operations and improved --prefix flag documentation for deterministic email addresses in CI environments. All tests pass successfully.
+**Evidence:** PR #19 merged on May 2, 2025. Added proper handling of HTTP 201 and 202 status codes for idempotent operations and improved --prefix flag documentation for deterministic email addresses in CI environments. All tests pass successfully.
 
 ---
 
@@ -135,7 +135,7 @@ This PR adds API edge case documentation and implements version header handling.
 **Merge when these checkboxes are green:**
 - [x] Payload structure validated.
 
-**Evidence:** PR #20 merged on May 2, 2025. Implemented simulate_events.py with proper metric_id handling inside the metric object and added comprehensive tests that all pass successfully.
+**Evidence:** PR #7 merged on May 2, 2025. Implemented simulate_events.py with proper metric_id handling inside the metric object and added comprehensive tests that all pass successfully.
 
 ---
 


### PR DESCRIPTION
This PR fixes the PR numbering in the GitHub PR Plan to correctly reflect:

1. PR #19 for PR 6 (Profile Seeding & Flags)
2. PR #7 for PR 7 (Simulate Events Script)

The PR numbers in the evidence sections were incorrect and have been updated to match the actual PR numbers that were merged.