### PR TITLE
PR 11: Documentation & Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 # Klaviyo Mock Reporting Data Generator
 
-This script generates realistic mock data in Klaviyo to power reporting demos, test automations, and showcase value to clients.
+This script generates realistic mock data in Klaviyo to power reporting demos, test
+automations, and showcase value to clients.
+
+## Workflow
+
+![Klaviyo Reporting Workflow](docs/img/flow.svg)
 
 ## Features
 
 - **Mock List Creation**: Creates a test list named `Mock_Reporting_List`
-- **Mock Profile Generation**: Adds 20-30 realistic but fictional profiles to the list
+- **Mock Profile Generation**: Adds 20-30 realistic but fictional profiles to the
+  list
 - **Campaign Activity Simulation**: Simulates events for two mock campaigns
 - **Flow Events Simulation**: Creates a mock welcome flow with message interactions
-- **Purchase Behavior Simulation**: Generates realistic purchase events with product data
+- **Purchase Behavior Simulation**: Generates realistic purchase events with product
+  data
 
 ## Requirements
 
@@ -19,7 +26,8 @@ This script generates realistic mock data in Klaviyo to power reporting demos, t
 ## API Version
 
 - All scripts use Klaviyo API revision **2025-04-15**
-- See [API Usage Guidelines](docs/api_usage.md) for important information about API versioning and edge cases
+- See [API Usage Guidelines](docs/api_usage.md) for important information about API
+  versioning and edge cases
 - TODO: Make API revision an environment variable to simplify future updates
 
 ## Installation
@@ -32,7 +40,7 @@ pip install -r requirements.txt
 
 Copy `.env.example` to `.env` and update with your values:
 
-```
+```bash
 KLAVIYO_API_KEY=pk_xxx
 AUDIENCE_ID=YdSN6t
 CAMPAIGN_ID=AbCdEf
@@ -55,6 +63,7 @@ python mock_klaviyo_reporting_data.py
 ```
 
 Alternatively, you can still use the legacy method:
+
 1. Ensure your Klaviyo API key is in `private-api-key.txt` (should start with `pk_`)
 2. Run the script as above
 
@@ -66,12 +75,13 @@ To send campaign performance reports to Slack:
 python slack_integration.py
 ```
 
-This will format the metrics and insights into a nicely formatted Slack message with links to the Looker Studio dashboard.
+This will format the metrics and insights into a nicely formatted Slack message with
+links to the Looker Studio dashboard.
 
 ## What Gets Created
 
 1. **List**: `Mock_Reporting_List` with 25 profiles
-2. **Campaigns**: 
+2. **Campaigns**:
    - `Mock_Welcome_Campaign`
    - `Mock_Product_Update`
 3. **Flow**: `Mock_Welcome_Flow`
@@ -93,6 +103,7 @@ This will format the metrics and insights into a nicely formatted Slack message 
 ## Troubleshooting
 
 If you encounter API errors:
+
 - Verify your API key is correct and has proper permissions
 - Check that the key in private-api-key.txt doesn't have trailing whitespace
 - The script includes rate limiting to avoid overwhelming the Klaviyo API
@@ -108,11 +119,15 @@ If you encounter API errors:
 
 ⚠️ **IMPORTANT: All developers must follow the GitHub PR Plan** ⚠️
 
-This project follows a structured development process outlined in the [GitHub PR Plan](docs/GITHUB_PR_PLAN.md). Before creating any PRs or making changes, please review this document.
+This project follows a structured development process outlined in the
+[GitHub PR Plan](docs/GITHUB_PR_PLAN.md). Before creating any PRs or making changes,
+please review this document.
 
 All PRs must:
+
 1. Reference the PR Plan in the description
 2. Include the PR number and title from the plan in your PR title
 3. Align with one of the items in the plan
 
-Do not create PRs that are not part of the plan without discussing with the team first.
+Do not create PRs that are not part of the plan without discussing with the team
+first.

--- a/docs/img/flow.svg
+++ b/docs/img/flow.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="800" height="200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="800" height="200" fill="#f8f9fa" rx="10" ry="10"/>
+  
+  <!-- Boxes -->
+  <rect x="50" y="70" width="120" height="60" rx="5" ry="5" fill="#e1f5fe" stroke="#0288d1" stroke-width="2"/>
+  <rect x="220" y="70" width="120" height="60" rx="5" ry="5" fill="#e8f5e9" stroke="#388e3c" stroke-width="2"/>
+  <rect x="390" y="70" width="120" height="60" rx="5" ry="5" fill="#fff3e0" stroke="#f57c00" stroke-width="2"/>
+  <rect x="560" y="70" width="120" height="60" rx="5" ry="5" fill="#f3e5f5" stroke="#7b1fa2" stroke-width="2"/>
+  <rect x="730" y="70" width="120" height="60" rx="5" ry="5" fill="#e0f7fa" stroke="#00acc1" stroke-width="2"/>
+  
+  <!-- Arrows -->
+  <line x1="170" y1="100" x2="220" y2="100" stroke="#757575" stroke-width="2" marker-end="url(#arrowhead)"/>
+  <line x1="340" y1="100" x2="390" y2="100" stroke="#757575" stroke-width="2" marker-end="url(#arrowhead)"/>
+  <line x1="510" y1="100" x2="560" y2="100" stroke="#757575" stroke-width="2" marker-end="url(#arrowhead)"/>
+  <line x1="680" y1="100" x2="730" y2="100" stroke="#757575" stroke-width="2" marker-end="url(#arrowhead)"/>
+  
+  <!-- Text -->
+  <text x="110" y="105" font-family="Arial" font-size="14" text-anchor="middle" fill="#01579b">Seed Profiles</text>
+  <text x="280" y="105" font-family="Arial" font-size="14" text-anchor="middle" fill="#1b5e20">Send Campaign</text>
+  <text x="450" y="105" font-family="Arial" font-size="14" text-anchor="middle" fill="#e65100">Fetch Metrics</text>
+  <text x="620" y="105" font-family="Arial" font-size="14" text-anchor="middle" fill="#4a148c">GPT Insights</text>
+  <text x="790" y="105" font-family="Arial" font-size="14" text-anchor="middle" fill="#006064">Looker Studio</text>
+  
+  <!-- Title -->
+  <text x="400" y="30" font-family="Arial" font-size="18" font-weight="bold" text-anchor="middle" fill="#212121">Klaviyo Reporting Workflow</text>
+  
+  <!-- Arrow Definitions -->
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#757575"/>
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
Implements PR #11 from the [GitHub PR Plan](docs/GITHUB_PR_PLAN.md).

This PR:
- Moves call-flow diagram to  and references it in README
- Lints README with Usage: markdownlint [options] [files|directories|globs...]

MarkdownLint Command Line Interface

Arguments:
  files|directories|globs                    files, directories, and/or globs to lint

Options:
  -V, --version                              output the version number
  -c, --config <configFile>                  configuration file (JSON, JSONC, JS, YAML, or TOML)
  --configPointer <pointer>                  JSON Pointer to object within configuration file (default: "")
  -d, --dot                                  include files/folders with a dot (for example `.github`)
  -f, --fix                                  fix basic errors (does not work with STDIN)
  -i, --ignore <file|directory|glob>         file(s) to ignore/exclude (default: [])
  -j, --json                                 write issues in json format
  -o, --output <outputFile>                  write issues to file (no console)
  -p, --ignore-path <file>                   path to file with ignore pattern(s)
  -q, --quiet                                do not write issues to STDOUT
  -r, --rules <file|directory|glob|package>  include custom rule files (default: [])
  -s, --stdin                                read from STDIN (does not work with files)
  --enable <rules...>                        Enable certain rules, e.g. --enable MD013 MD041 --
  --disable <rules...>                       Disable certain rules, e.g. --disable MD013 MD041 --
  -h, --help                                 display help for command

## Validation
1.  exists and README displays it
2.  returns no errors

## Evidence
- Created SVG diagram showing the workflow: seed → send → fetch → GPT → Looker
- Added diagram to README in a new Workflow section
- Fixed all markdownlint issues in README.md