### PR TITLE
PR 2: LookML Field Mapper

### DIFF
--- a/src/lookml_field_mapper.py
+++ b/src/lookml_field_mapper.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from datetime import datetime
+
+# Field mapping dictionary
+FIELD_MAP = {
+    # Klaviyo field name -> Looker Studio field name
+    "send_time": "date",
+    "name": "campaign_name",
+    "subject": "subject_line",
+    "open_rate": "open_rate",
+    "click_rate": "click_rate",
+    "list_id": "list_id"
+}
+
+# Additional derived fields that need to be calculated
+DERIVED_FIELDS = {
+    # Derived field name -> Function to calculate it
+    "engagement_score": lambda record: (record.get("open_rate", 0) * 0.7 + record.get("click_rate", 0) * 0.3)
+}
+
+def format_date(date_str):
+    """Format a date string to YYYY-MM-DD format"""
+    if not date_str:
+        return ""
+    
+    try:
+        # Handle ISO format dates (e.g., "2025-05-01T10:00:00Z")
+        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        # If it's already in the right format or can't be parsed, return as is
+        return date_str
+
+def normalize_record(raw_record):
+    """Normalize a single record from Klaviyo format to Looker Studio format"""
+    if not raw_record:
+        return {}
+    
+    normalized = {}
+    
+    # Map standard fields
+    for klaviyo_field, looker_field in FIELD_MAP.items():
+        if klaviyo_field in raw_record:
+            # Apply special formatting for date fields
+            if klaviyo_field == "send_time":
+                normalized[looker_field] = format_date(raw_record[klaviyo_field])
+            else:
+                normalized[looker_field] = raw_record[klaviyo_field]
+    
+    # Calculate derived fields
+    for derived_field, calc_func in DERIVED_FIELDS.items():
+        try:
+            normalized[derived_field] = calc_func(raw_record)
+        except Exception as e:
+            print(f"Error calculating derived field {derived_field}: {e}")
+    
+    # Pass through any fields that aren't mapped but might be useful
+    for field in raw_record:
+        if field not in FIELD_MAP and field not in normalized:
+            normalized[field] = raw_record[field]
+    
+    return normalized
+
+def normalize_records(raw_records):
+    """Normalize a list of records from Klaviyo format to Looker Studio format"""
+    if not raw_records:
+        return []
+    
+    return [normalize_record(record) for record in raw_records]
+
+def get_field_mapping():
+    """Return the field mapping dictionary"""
+    return FIELD_MAP.copy()
+
+def get_derived_fields():
+    """Return the derived fields dictionary"""
+    return DERIVED_FIELDS.copy()
+
+# Main function for testing
+def main():
+    # Example usage
+    import json
+    
+    # Sample Klaviyo records
+    sample_records = [
+        {
+            "id": "campaign_123",
+            "name": "Test Campaign 1",
+            "send_time": "2025-05-01T10:00:00Z",
+            "subject": "Test Subject 1",
+            "open_rate": 0.45,
+            "click_rate": 0.20,
+            "list_id": "list_123"
+        },
+        {
+            "id": "campaign_456",
+            "name": "Test Campaign 2",
+            "send_time": "2025-05-08T10:00:00Z",
+            "subject": "Test Subject 2",
+            "open_rate": 0.50,
+            "click_rate": 0.25,
+            "list_id": "list_123"
+        }
+    ]
+    
+    # Normalize the records
+    normalized = normalize_records(sample_records)
+    
+    # Print the result
+    print("Original records:")
+    print(json.dumps(sample_records, indent=2))
+    print("\nNormalized records:")
+    print(json.dumps(normalized, indent=2))
+    
+    # Print field mapping
+    print("\nField mapping:")
+    for k, v in get_field_mapping().items():
+        print(f"  {k} -> {v}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lookml_field_mapper.py
+++ b/tests/test_lookml_field_mapper.py
@@ -1,4 +1,10 @@
 import pytest
+import sys
+import os
+
+# Add the project root directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from src.lookml_field_mapper import (
     normalize_record,
     normalize_records,

--- a/tests/test_lookml_field_mapper.py
+++ b/tests/test_lookml_field_mapper.py
@@ -1,0 +1,109 @@
+import pytest
+from src.lookml_field_mapper import (
+    normalize_record,
+    normalize_records,
+    get_field_mapping,
+    get_derived_fields,
+    format_date
+)
+
+# Test field mapping
+def test_get_field_mapping():
+    mapping = get_field_mapping()
+    assert isinstance(mapping, dict)
+    assert "send_time" in mapping
+    assert mapping["send_time"] == "date"
+    assert "name" in mapping
+    assert mapping["name"] == "campaign_name"
+
+# Test derived fields
+def test_get_derived_fields():
+    derived = get_derived_fields()
+    assert isinstance(derived, dict)
+    assert "engagement_score" in derived
+    
+    # Test the engagement score calculation
+    test_record = {"open_rate": 0.6, "click_rate": 0.4}
+    score = derived["engagement_score"](test_record)
+    assert score == pytest.approx(0.6 * 0.7 + 0.4 * 0.3)
+
+# Test normalize_record with complete data
+def test_normalize_record_complete():
+    raw_record = {
+        "id": "campaign_123",
+        "name": "Test Campaign",
+        "send_time": "2025-05-01T10:00:00Z",
+        "subject": "Test Subject",
+        "open_rate": 0.45,
+        "click_rate": 0.20,
+        "list_id": "list_123"
+    }
+    
+    normalized = normalize_record(raw_record)
+    
+    assert normalized["campaign_name"] == "Test Campaign"
+    assert normalized["date"] == "2025-05-01"
+    assert normalized["subject_line"] == "Test Subject"
+    assert normalized["open_rate"] == 0.45
+    assert normalized["click_rate"] == 0.20
+    assert normalized["list_id"] == "list_123"
+    assert "id" in normalized  # Unmapped fields should be passed through
+    assert "engagement_score" in normalized
+    assert normalized["engagement_score"] == pytest.approx(0.45 * 0.7 + 0.20 * 0.3)
+
+# Test normalize_record with missing fields
+def test_normalize_record_missing_fields():
+    raw_record = {
+        "id": "campaign_123",
+        "name": "Test Campaign"
+        # Missing other fields
+    }
+    
+    normalized = normalize_record(raw_record)
+    
+    assert normalized["campaign_name"] == "Test Campaign"
+    assert "date" not in normalized
+    assert "subject_line" not in normalized
+    assert "id" in normalized  # Unmapped fields should be passed through
+    assert "engagement_score" in normalized
+    assert normalized["engagement_score"] == 0  # Default values are 0
+
+# Test normalize_record with empty input
+def test_normalize_record_empty():
+    assert normalize_record({}) == {}
+    assert normalize_record(None) == {}
+
+# Test normalize_records with multiple records
+def test_normalize_records():
+    raw_records = [
+        {
+            "id": "campaign_1",
+            "name": "Test Campaign 1",
+            "send_time": "2025-05-01T10:00:00Z"
+        },
+        {
+            "id": "campaign_2",
+            "name": "Test Campaign 2",
+            "send_time": "2025-05-02T10:00:00Z"
+        }
+    ]
+    
+    normalized = normalize_records(raw_records)
+    
+    assert len(normalized) == 2
+    assert normalized[0]["campaign_name"] == "Test Campaign 1"
+    assert normalized[0]["date"] == "2025-05-01"
+    assert normalized[1]["campaign_name"] == "Test Campaign 2"
+    assert normalized[1]["date"] == "2025-05-02"
+
+# Test normalize_records with empty input
+def test_normalize_records_empty():
+    assert normalize_records([]) == []
+    assert normalize_records(None) == []
+
+# Test date formatting
+def test_format_date():
+    assert format_date("2025-05-01T10:00:00Z") == "2025-05-01"
+    assert format_date("2025-05-01") == "2025-05-01"  # Already in correct format
+    assert format_date("") == ""
+    assert format_date(None) == ""


### PR DESCRIPTION
Implements PR #2 from the [Narrow Scope POC PR Plan](docs/NARROW_SCOPE_POC_PR_PLAN.md).

This PR adds the lookml_field_mapper.py script for normalizing Klaviyo fields for Looker Studio.

## Changes
- Created Original records:
[
  {
    "id": "campaign_123",
    "name": "Test Campaign 1",
    "send_time": "2025-05-01T10:00:00Z",
    "subject": "Test Subject 1",
    "open_rate": 0.45,
    "click_rate": 0.2,
    "list_id": "list_123"
  },
  {
    "id": "campaign_456",
    "name": "Test Campaign 2",
    "send_time": "2025-05-08T10:00:00Z",
    "subject": "Test Subject 2",
    "open_rate": 0.5,
    "click_rate": 0.25,
    "list_id": "list_123"
  }
]

Normalized records:
[
  {
    "date": "2025-05-01",
    "campaign_name": "Test Campaign 1",
    "subject_line": "Test Subject 1",
    "open_rate": 0.45,
    "click_rate": 0.2,
    "list_id": "list_123",
    "engagement_score": 0.375,
    "id": "campaign_123"
  },
  {
    "date": "2025-05-08",
    "campaign_name": "Test Campaign 2",
    "subject_line": "Test Subject 2",
    "open_rate": 0.5,
    "click_rate": 0.25,
    "list_id": "list_123",
    "engagement_score": 0.425,
    "id": "campaign_456"
  }
]

Field mapping:
  send_time -> date
  name -> campaign_name
  subject -> subject_line
  open_rate -> open_rate
  click_rate -> click_rate
  list_id -> list_id for normalizing Klaviyo fields
- Implemented mapping dictionary from raw Klaviyo field names to reporting-ready field names
- Added unit tests in 
- Ensured the mapper can be reused in pipeline or mock data setup

## Validation
- ✅ Run unit tests with ============================= test session starts ==============================
platform darwin -- Python 3.13.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/tdeshane/clara-strategy-session/klaviyo-reporting-poc
configfile: pytest.ini
plugins: Faker-37.1.0
collected 8 items

tests/test_lookml_field_mapper.py ........                               [100%]

============================== 8 passed in 0.02s ===============================
- ✅ Verified mapping works with sample Klaviyo API response
- ✅ All required fields are mapped correctly
- ✅ Edge cases are handled (missing fields, null values, etc.)

## Checklist
- [x] All validation steps passed
- [x] Code follows project style guidelines
- [x] Unit tests cover key functionality