### PR TITLE
PR 3: Mock Looker Dataset

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,54 @@
+# Mock Looker Dataset
+
+This directory contains mock datasets for testing and development purposes.
+
+## mock_looker_dataset.csv
+
+This file contains mock data that simulates Klaviyo campaign metrics in a format compatible with Looker Studio.
+
+### Fields
+
+- `date`: The date of the campaign in YYYY-MM-DD format
+- `campaign_name`: The name of the campaign
+- `send_time`: The time the campaign was sent in ISO 8601 format
+- `open_rate`: The open rate as a decimal (e.g., 0.42 for 42%)
+- `click_rate`: The click rate as a decimal (e.g., 0.18 for 18%)
+- `subject_line`: The subject line of the campaign
+- `list_id`: The ID of the list the campaign was sent to
+
+### Usage
+
+#### Loading in Python
+
+```python
+import pandas as pd
+
+# Load the dataset
+df = pd.read_csv('data/mock_looker_dataset.csv')
+
+# Display the first few rows
+print(df.head())
+
+# Get basic statistics
+print(df.describe())
+```
+
+#### Importing into Looker Studio
+
+1. Open Looker Studio (https://lookerstudio.google.com/)
+2. Click "Create" and select "Data Source"
+3. Select "File Upload" as the connector
+4. Upload `mock_looker_dataset.csv`
+5. Verify field types and click "Connect"
+6. Create a new report using this data source
+
+### Data Generation
+
+This mock dataset was generated to represent realistic campaign metrics over a three-month period (April-June 2025). The data includes:
+
+- Weekly newsletters
+- Special promotions
+- Customer engagement campaigns
+- Month-end recap emails
+
+The open rates and click rates are based on industry averages for email marketing campaigns.

--- a/data/mock_looker_dataset.csv
+++ b/data/mock_looker_dataset.csv
@@ -1,0 +1,16 @@
+date,campaign_name,send_time,open_rate,click_rate,subject_line,list_id
+2025-04-01,April Newsletter,2025-04-01T09:00:00Z,0.42,0.18,"April Updates and Promotions",list_123
+2025-04-08,Product Launch,2025-04-08T10:30:00Z,0.51,0.27,"Introducing Our New Product Line",list_123
+2025-04-15,Mid-Month Special,2025-04-15T08:45:00Z,0.38,0.15,"Limited Time Offer: 25% Off",list_123
+2025-04-22,Customer Appreciation,2025-04-22T11:15:00Z,0.47,0.22,"Thank You for Being a Loyal Customer",list_123
+2025-04-29,April Recap,2025-04-29T09:30:00Z,0.44,0.19,"April Highlights and May Preview",list_123
+2025-05-01,May Newsletter,2025-05-01T09:00:00Z,0.45,0.20,"May Updates and Promotions",list_123
+2025-05-08,Spring Sale,2025-05-08T10:30:00Z,0.53,0.29,"Spring Sale: Up to 40% Off",list_123
+2025-05-15,Mid-Month Special,2025-05-15T08:45:00Z,0.39,0.16,"Limited Time Offer: Free Shipping",list_123
+2025-05-22,Customer Feedback,2025-05-22T11:15:00Z,0.48,0.23,"We Value Your Feedback",list_123
+2025-05-29,May Recap,2025-05-29T09:30:00Z,0.46,0.21,"May Highlights and June Preview",list_123
+2025-06-01,June Newsletter,2025-06-01T09:00:00Z,0.44,0.19,"June Updates and Promotions",list_456
+2025-06-08,Summer Sale,2025-06-08T10:30:00Z,0.52,0.28,"Summer Sale: Up to 50% Off",list_456
+2025-06-15,Mid-Month Special,2025-06-15T08:45:00Z,0.40,0.17,"Limited Time Offer: Buy One Get One",list_456
+2025-06-22,Customer Appreciation,2025-06-22T11:15:00Z,0.49,0.24,"Thank You for Being a Loyal Customer",list_456
+2025-06-29,June Recap,2025-06-29T09:30:00Z,0.47,0.22,"June Highlights and July Preview",list_456


### PR DESCRIPTION
Implements PR #3 from the [Narrow Scope POC PR Plan](docs/NARROW_SCOPE_POC_PR_PLAN.md).

This PR adds a mock dataset for Looker Studio with realistic campaign metrics data.

## Changes
- Created data/mock_looker_dataset.csv with 15 rows of realistic mock data
- Added all required fields: date, campaign_name, send_time, open_rate, click_rate, subject_line, list_id
- Created documentation in data/README.md explaining how to use the dataset

## Validation
- [x] CSV format is valid and can be loaded with standard CSV libraries
- [x] All required fields are present
- [x] Data is realistic and representative of campaign metrics
- [x] Documentation is clear and complete