### PR TITLE
PR 7: Supermetrics → CSV Pull Script

### DIFF
--- a/src/supermetrics_klaviyo_pull.py
+++ b/src/supermetrics_klaviyo_pull.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+import os
+import sys
+import json
+import csv
+import argparse
+import time
+from datetime import datetime, date
+import requests
+
+# Constants
+SUPERMETRICS_API_ENDPOINT = "https://api.supermetrics.com/enterprise/v2/query/data/json"
+DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data")
+REPORT_TYPE_MAP = {
+    "campaign": "klaviyo_campaigns",
+    "events": "klaviyo_email_events"
+}
+
+# Configuration
+def get_api_key():
+    api_key = os.getenv("SUPERMETRICS_API_KEY")
+    if not api_key:
+        raise ValueError("SUPERMETRICS_API_KEY environment variable not set")
+    return api_key
+
+# API Functions
+def fetch_data(start_date, end_date, report_type, page_token=None, dry_run=False):
+    api_key = get_api_key()
+    ds_id = REPORT_TYPE_MAP.get(report_type)
+    if not ds_id:
+        raise ValueError(f"Invalid report type: {report_type}. Must be one of {list(REPORT_TYPE_MAP.keys())}")
+    
+    headers = {
+        "Content-Type": "application/json",
+        "api_key": api_key
+    }
+    
+    payload = {
+        "ds_id": ds_id,
+        "start_date": start_date,
+        "end_date": end_date,
+        "fields": ["*"]  # Request all available fields
+    }
+    
+    if page_token:
+        payload["page_token"] = page_token
+    
+    if dry_run:
+        print(f"[DRY RUN] Would fetch {report_type} data with payload: {payload}")
+        # Return mock data for dry run
+        if report_type == "campaign":
+            mock_data = [
+                {
+                    "campaign_id": "campaign_123",
+                    "campaign_name": "Test Campaign 1",
+                    "send_time": "2025-05-01T10:00:00Z",
+                    "subject_line": "Test Subject 1",
+                    "open_rate": 0.45,
+                    "click_rate": 0.20,
+                    "delivered": 1000,
+                    "opened": 450,
+                    "clicked": 200
+                },
+                {
+                    "campaign_id": "campaign_456",
+                    "campaign_name": "Test Campaign 2",
+                    "send_time": "2025-05-08T10:00:00Z",
+                    "subject_line": "Test Subject 2",
+                    "open_rate": 0.50,
+                    "click_rate": 0.25,
+                    "delivered": 800,
+                    "opened": 400,
+                    "clicked": 200
+                }
+            ]
+        else:  # events
+            mock_data = [
+                {
+                    "event_id": "event_123",
+                    "campaign_id": "campaign_123",
+                    "event_name": "Open",
+                    "event_time": "2025-05-01T12:30:00Z",
+                    "email": "user1@example.com",
+                    "device": "Mobile"
+                },
+                {
+                    "event_id": "event_456",
+                    "campaign_id": "campaign_123",
+                    "event_name": "Click",
+                    "event_time": "2025-05-01T12:35:00Z",
+                    "email": "user1@example.com",
+                    "device": "Mobile"
+                }
+            ]
+        
+        # Simulate pagination for dry run
+        next_token = "mock_page_2" if not page_token else None
+        return mock_data, next_token
+    
+    max_retries = 5
+    retry_count = 0
+    backoff_time = 1
+    
+    while retry_count < max_retries:
+        try:
+            response = requests.post(
+                SUPERMETRICS_API_ENDPOINT,
+                headers=headers,
+                json=payload,
+                timeout=30
+            )
+            
+            # Handle rate limiting
+            if response.status_code == 429:
+                retry_after = int(response.headers.get("Retry-After", backoff_time))
+                print(f"Rate limited. Retrying after {retry_after} seconds...")
+                time.sleep(retry_after)
+                retry_count += 1
+                backoff_time = min(backoff_time * 2, 60)  # Exponential backoff, max 60 seconds
+                continue
+            
+            # Handle server errors
+            if response.status_code >= 500:
+                print(f"Server error (HTTP {response.status_code}). Retrying after {backoff_time} seconds...")
+                time.sleep(backoff_time)
+                retry_count += 1
+                backoff_time = min(backoff_time * 2, 60)  # Exponential backoff, max 60 seconds
+                continue
+            
+            # Raise for other HTTP errors
+            response.raise_for_status()
+            
+            data = response.json()
+            return data.get("data", []), data.get("next_page_token")
+            
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching data: {e}")
+            retry_count += 1
+            if retry_count < max_retries:
+                print(f"Retrying in {backoff_time} seconds...")
+                time.sleep(backoff_time)
+                backoff_time = min(backoff_time * 2, 60)  # Exponential backoff, max 60 seconds
+            else:
+                print(f"Max retries ({max_retries}) reached. Giving up.")
+                return [], None
+    
+    return [], None
+
+def fetch_all_data(start_date, end_date, report_type, dry_run=False):
+    all_data = []
+    page_token = None
+    page_count = 0
+    max_pages = 100  # Safety limit
+    
+    print(f"Fetching {report_type} data from {start_date} to {end_date}...")
+    
+    while page_count < max_pages:
+        data, next_page_token = fetch_data(start_date, end_date, report_type, page_token, dry_run)
+        all_data.extend(data)
+        page_token = next_page_token
+        page_count += 1
+        
+        print(f"Fetched page {page_count} with {len(data)} records. Total records: {len(all_data)}")
+        
+        if not page_token:
+            break
+        
+        # Respect rate limits
+        time.sleep(6)  # ~10 queries per minute
+    
+    if page_count >= max_pages:
+        print(f"Warning: Reached maximum page limit ({max_pages}). Data may be incomplete.")
+    
+    return all_data
+
+# Output Functions
+def write_to_json(data, report_type, dry_run=False):
+    if not data:
+        print("No data to write to JSON")
+        return None
+    
+    # Create data directory if it doesn't exist
+    os.makedirs(DATA_DIR, exist_ok=True)
+    
+    # Generate filename with current date
+    timestamp = date.today().strftime("%Y%m%d")
+    output_file = os.path.join(DATA_DIR, f"supermetrics_raw_{report_type}_{timestamp}.json")
+    
+    if dry_run:
+        print(f"[DRY RUN] Would write {len(data)} records to {output_file}")
+        return output_file
+    
+    try:
+        with open(output_file, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        print(f"Data written to {output_file}")
+        return output_file
+    except Exception as e:
+        print(f"Error writing to JSON: {e}")
+        return None
+
+def write_to_csv(data, json_file, dry_run=False):
+    if not data or not json_file:
+        print("No data or JSON file path to write CSV")
+        return None
+    
+    # Generate CSV filename based on JSON filename
+    output_file = json_file.replace(".json", ".csv")
+    
+    if dry_run:
+        print(f"[DRY RUN] Would write {len(data)} records to {output_file}")
+        return output_file
+    
+    try:
+        # Get all unique field names from the data
+        fieldnames = set()
+        for record in data:
+            fieldnames.update(record.keys())
+        fieldnames = sorted(list(fieldnames))
+        
+        with open(output_file, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in data:
+                writer.writerow(row)
+        print(f"Data written to {output_file}")
+        return output_file
+    except Exception as e:
+        print(f"Error writing to CSV: {e}")
+        return None
+
+# Main Function
+def main():
+    parser = argparse.ArgumentParser(description="Fetch Klaviyo data via Supermetrics API")
+    parser.add_argument("--start-date", required=True, help="Start date in YYYY-MM-DD format")
+    parser.add_argument("--end-date", required=True, help="End date in YYYY-MM-DD format")
+    parser.add_argument("--report-type", required=True, choices=["campaign", "events"], 
+                        help="Type of report to fetch (campaign or events)")
+    parser.add_argument("--dry-run", action="store_true", help="Perform a dry run without making actual API calls")
+    parser.add_argument("--csv", action="store_true", help="Also output data as CSV")
+    args = parser.parse_args()
+    
+    # Validate dates
+    try:
+        datetime.strptime(args.start_date, "%Y-%m-%d")
+        datetime.strptime(args.end_date, "%Y-%m-%d")
+    except ValueError:
+        print("Error: Dates must be in YYYY-MM-DD format")
+        return 1
+    
+    # Fetch data
+    data = fetch_all_data(args.start_date, args.end_date, args.report_type, args.dry_run)
+    
+    if not data:
+        print("No data fetched. Exiting.")
+        return 1
+    
+    # Write to JSON
+    json_file = write_to_json(data, args.report_type, args.dry_run)
+    
+    # Write to CSV if requested
+    if args.csv and json_file:
+        write_to_csv(data, json_file, args.dry_run)
+    
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_supermetrics_klaviyo_pull.py
+++ b/tests/test_supermetrics_klaviyo_pull.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+import os
+import json
+import pytest
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+from datetime import date
+
+# Import the module to test
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from src.supermetrics_klaviyo_pull import (
+    fetch_data,
+    fetch_all_data,
+    write_to_json,
+    write_to_csv,
+    REPORT_TYPE_MAP
+)
+
+# Test fixtures
+@pytest.fixture
+def mock_api_key():
+    with patch.dict(os.environ, {"SUPERMETRICS_API_KEY": "test_api_key"}):
+        yield
+
+@pytest.fixture
+def temp_data_dir():
+    temp_dir = tempfile.mkdtemp()
+    with patch("src.supermetrics_klaviyo_pull.DATA_DIR", temp_dir):
+        yield temp_dir
+    shutil.rmtree(temp_dir)
+
+@pytest.fixture
+def mock_campaign_data():
+    return [
+        {
+            "campaign_id": "campaign_123",
+            "campaign_name": "Test Campaign 1",
+            "send_time": "2025-05-01T10:00:00Z",
+            "subject_line": "Test Subject 1",
+            "open_rate": 0.45,
+            "click_rate": 0.20,
+            "delivered": 1000,
+            "opened": 450,
+            "clicked": 200
+        },
+        {
+            "campaign_id": "campaign_456",
+            "campaign_name": "Test Campaign 2",
+            "send_time": "2025-05-08T10:00:00Z",
+            "subject_line": "Test Subject 2",
+            "open_rate": 0.50,
+            "click_rate": 0.25,
+            "delivered": 800,
+            "opened": 400,
+            "clicked": 200
+        }
+    ]
+
+@pytest.fixture
+def mock_events_data():
+    return [
+        {
+            "event_id": "event_123",
+            "campaign_id": "campaign_123",
+            "event_name": "Open",
+            "event_time": "2025-05-01T12:30:00Z",
+            "email": "user1@example.com",
+            "device": "Mobile"
+        },
+        {
+            "event_id": "event_456",
+            "campaign_id": "campaign_123",
+            "event_name": "Click",
+            "event_time": "2025-05-01T12:35:00Z",
+            "email": "user1@example.com",
+            "device": "Mobile"
+        }
+    ]
+
+# Tests
+@pytest.mark.parametrize("report_type,ds_id", [
+    ("campaign", "klaviyo_campaigns"),
+    ("events", "klaviyo_email_events")
+])
+def test_report_type_mapping(report_type, ds_id):
+    assert REPORT_TYPE_MAP[report_type] == ds_id
+
+@patch("src.supermetrics_klaviyo_pull.requests.post")
+def test_fetch_data_success(mock_post, mock_api_key, mock_campaign_data):
+    # Setup mock response
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": mock_campaign_data,
+        "next_page_token": "next_page"
+    }
+    mock_post.return_value = mock_response
+    
+    # Call the function
+    data, next_page_token = fetch_data("2025-05-01", "2025-05-31", "campaign")
+    
+    # Assertions
+    assert data == mock_campaign_data
+    assert next_page_token == "next_page"
+    mock_post.assert_called_once()
+    
+    # Check that the correct payload was sent
+    call_args = mock_post.call_args[1]
+    assert call_args["json"]["ds_id"] == "klaviyo_campaigns"
+    assert call_args["json"]["start_date"] == "2025-05-01"
+    assert call_args["json"]["end_date"] == "2025-05-31"
+
+@patch("src.supermetrics_klaviyo_pull.requests.post")
+def test_fetch_data_with_pagination(mock_post, mock_api_key):
+    # Setup mock responses for pagination
+    mock_response1 = MagicMock()
+    mock_response1.status_code = 200
+    mock_response1.json.return_value = {
+        "data": [{"id": "1"}],
+        "next_page_token": "page2"
+    }
+    
+    mock_response2 = MagicMock()
+    mock_response2.status_code = 200
+    mock_response2.json.return_value = {
+        "data": [{"id": "2"}],
+        "next_page_token": None
+    }
+    
+    mock_post.side_effect = [mock_response1, mock_response2]
+    
+    # Call the function with pagination
+    with patch("src.supermetrics_klaviyo_pull.time.sleep"):
+        data = fetch_all_data("2025-05-01", "2025-05-31", "campaign")
+    
+    # Assertions
+    assert len(data) == 2
+    assert data[0]["id"] == "1"
+    assert data[1]["id"] == "2"
+    assert mock_post.call_count == 2
+
+@patch("src.supermetrics_klaviyo_pull.requests.post")
+def test_fetch_data_rate_limit_retry(mock_post, mock_api_key):
+    # Setup mock responses for rate limiting
+    mock_response1 = MagicMock()
+    mock_response1.status_code = 429
+    mock_response1.headers = {"Retry-After": "1"}
+    
+    mock_response2 = MagicMock()
+    mock_response2.status_code = 200
+    mock_response2.json.return_value = {
+        "data": [{"id": "1"}],
+        "next_page_token": None
+    }
+    
+    mock_post.side_effect = [mock_response1, mock_response2]
+    
+    # Call the function with rate limiting
+    with patch("src.supermetrics_klaviyo_pull.time.sleep"):
+        data, next_page_token = fetch_data("2025-05-01", "2025-05-31", "campaign")
+    
+    # Assertions
+    assert data == [{"id": "1"}]
+    assert next_page_token is None
+    assert mock_post.call_count == 2
+
+@patch("src.supermetrics_klaviyo_pull.requests.post")
+def test_fetch_data_server_error_retry(mock_post, mock_api_key):
+    # Setup mock responses for server error
+    mock_response1 = MagicMock()
+    mock_response1.status_code = 500
+    
+    mock_response2 = MagicMock()
+    mock_response2.status_code = 200
+    mock_response2.json.return_value = {
+        "data": [{"id": "1"}],
+        "next_page_token": None
+    }
+    
+    mock_post.side_effect = [mock_response1, mock_response2]
+    
+    # Call the function with server error
+    with patch("src.supermetrics_klaviyo_pull.time.sleep"):
+        data, next_page_token = fetch_data("2025-05-01", "2025-05-31", "campaign")
+    
+    # Assertions
+    assert data == [{"id": "1"}]
+    assert next_page_token is None
+    assert mock_post.call_count == 2
+
+def test_fetch_data_invalid_report_type(mock_api_key):
+    # Test with invalid report type
+    with pytest.raises(ValueError, match="Invalid report type"):
+        fetch_data("2025-05-01", "2025-05-31", "invalid_type")
+
+@patch("src.supermetrics_klaviyo_pull.requests.post")
+def test_fetch_data_empty_response(mock_post, mock_api_key):
+    # Setup mock response with empty data
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [],
+        "next_page_token": None
+    }
+    mock_post.return_value = mock_response
+    
+    # Call the function
+    data, next_page_token = fetch_data("2025-05-01", "2025-05-31", "campaign")
+    
+    # Assertions
+    assert data == []
+    assert next_page_token is None
+
+def test_write_to_json(temp_data_dir, mock_campaign_data):
+    # Test writing data to JSON
+    with patch("src.supermetrics_klaviyo_pull.date") as mock_date:
+        mock_date.today.return_value = date(2025, 5, 15)
+        json_file = write_to_json(mock_campaign_data, "campaign")
+    
+    # Assertions
+    assert json_file is not None
+    assert os.path.exists(json_file)
+    
+    # Verify file contents
+    with open(json_file, "r") as f:
+        saved_data = json.load(f)
+    assert saved_data == mock_campaign_data
+
+def test_write_to_csv(temp_data_dir, mock_campaign_data):
+    # First write JSON file
+    with patch("src.supermetrics_klaviyo_pull.date") as mock_date:
+        mock_date.today.return_value = date(2025, 5, 15)
+        json_file = write_to_json(mock_campaign_data, "campaign")
+    
+    # Then write CSV file
+    csv_file = write_to_csv(mock_campaign_data, json_file)
+    
+    # Assertions
+    assert csv_file is not None
+    assert os.path.exists(csv_file)
+    assert csv_file.endswith(".csv")
+    
+    # Verify file contents (basic check)
+    with open(csv_file, "r") as f:
+        header = f.readline().strip()
+    
+    # Check that all keys from the first record are in the header
+    for key in mock_campaign_data[0].keys():
+        assert key in header
+
+def test_write_to_json_empty_data(temp_data_dir):
+    # Test writing empty data to JSON
+    json_file = write_to_json([], "campaign")
+    assert json_file is None
+
+def test_write_to_csv_empty_data(temp_data_dir):
+    # Test writing empty data to CSV
+    csv_file = write_to_csv([], "some_file.json")
+    assert csv_file is None


### PR DESCRIPTION
Implements PR #7 from the [Narrow Scope POC PR Plan](docs/NARROW_SCOPE_POC_PR_PLAN.md).

This PR adds the  script for fetching Klaviyo data via the Supermetrics API.

## Implementation Details

- Created  CLI script that pulls Klaviyo data via Supermetrics API (JSON-based connector endpoint)
- Added authentication via  environment variable
- Implemented command-line parameters: , ,  (campaign | events)
- Added output to  and optional CSV format
- Implemented robust retry and rate-limit handling per Supermetrics guidelines
- Created comprehensive unit tests in  with mocked HTTP responses

## Validation Steps

1. Set the  environment variable
2. Run a dry-run: Fetching campaign data from 2025-05-01 to 2025-05-02...
3. Run a full fetch (if API credentials are available): Fetching campaign data from 2025-05-01 to 2025-05-02...
4. Verify the output files in the  directory
5. Run the unit tests: ============================= test session starts ==============================
platform darwin -- Python 3.13.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/tdeshane/clara-strategy-session/klaviyo-reporting-poc
configfile: pytest.ini
plugins: Faker-37.1.0
collected 12 items

tests/test_supermetrics_klaviyo_pull.py ............                     [100%]

============================== 12 passed in 0.07s ==============================

## Test Coverage

The unit tests cover:
- Successful API fetch with mocked 200 response
- Handling of pagination
- HTTP 429 retry logic (rate limit response)
- HTTP 500 retry logic (server error)
- Invalid report type handling
- Empty response handling
- Output file generation and schema consistency