### PR TITLE
PR 13: Fivetran API Client

### DIFF
--- a/src/fivetran_api_client.py
+++ b/src/fivetran_api_client.py
@@ -1,0 +1,194 @@
+import os
+import time
+import logging
+import requests
+from typing import Dict, Any, Optional, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+class FivetranAPIClient:
+    BASE_URL = "https://api.fivetran.com/v1"
+    
+    def __init__(self, api_key: str, api_secret: str):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.session = requests.Session()
+        self.session.auth = (self.api_key, self.api_secret)
+        self.session.headers.update({
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        })
+    
+    def _handle_response(self, response: requests.Response) -> Dict[str, Any]:
+        """Handle API response, including error cases."""
+        try:
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 429:
+                retry_after = int(response.headers.get("Retry-After", 60))
+                logger.warning(f"Rate limit exceeded. Retry after {retry_after} seconds.")
+                time.sleep(retry_after)
+                return self._retry_request(response.request)
+            
+            error_msg = f"HTTP error: {e}"
+            try:
+                error_data = response.json()
+                if "error" in error_data:
+                    error_msg = f"API error: {error_data['error']}"
+            except ValueError:
+                pass
+            
+            logger.error(error_msg)
+            raise
+    
+    def _retry_request(self, request) -> Dict[str, Any]:
+        """Retry a failed request."""
+        # If it's already a PreparedRequest, use it directly
+        if hasattr(request, 'url'):
+            response = self.session.send(request)
+        else:
+            # Otherwise, it's a Request object that needs to be prepared
+            prepared_request = self.session.prepare_request(request)
+            response = self.session.send(prepared_request)
+        return self._handle_response(response)
+    
+    def get_groups(self) -> List[Dict[str, Any]]:
+        """Get all groups."""
+        response = self.session.get(f"{self.BASE_URL}/groups")
+        data = self._handle_response(response)
+        return data.get("data", {}).get("items", [])
+    
+    def get_connectors(self, group_id: str) -> List[Dict[str, Any]]:
+        """Get all connectors for a group."""
+        response = self.session.get(f"{self.BASE_URL}/groups/{group_id}/connectors")
+        data = self._handle_response(response)
+        return data.get("data", {}).get("items", [])
+    
+    def get_connector(self, connector_id: str) -> Dict[str, Any]:
+        """Get details for a specific connector."""
+        response = self.session.get(f"{self.BASE_URL}/connectors/{connector_id}")
+        data = self._handle_response(response)
+        return data.get("data", {})
+    
+    def trigger_sync(self, connector_id: str) -> Dict[str, Any]:
+        """Trigger a sync for a connector."""
+        response = self.session.post(f"{self.BASE_URL}/connectors/{connector_id}/sync")
+        return self._handle_response(response)
+    
+    def get_sync_status(self, connector_id: str) -> Tuple[str, Optional[str]]:
+        """Get the current sync status for a connector.
+        
+        Returns:
+            Tuple of (status, error_message)
+        """
+        connector_data = self.get_connector(connector_id)
+        status = connector_data.get("status", {}).get("sync_state", "UNKNOWN")
+        error = connector_data.get("status", {}).get("sync_error", None)
+        return status, error
+    
+    def wait_for_sync_completion(self, connector_id: str, timeout: int = 3600, poll_interval: int = 30) -> bool:
+        """Wait for a sync to complete.
+        
+        Args:
+            connector_id: The connector ID
+            timeout: Maximum time to wait in seconds (default: 1 hour)
+            poll_interval: Time between status checks in seconds (default: 30 seconds)
+            
+        Returns:
+            True if sync completed successfully, False otherwise
+        """
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            status, error = self.get_sync_status(connector_id)
+            
+            if status == "SYNCING":
+                logger.info(f"Connector {connector_id} is syncing. Waiting {poll_interval} seconds...")
+                time.sleep(poll_interval)
+                continue
+                
+            if status == "SYNC_SUCCEEDED":
+                logger.info(f"Connector {connector_id} sync completed successfully.")
+                return True
+                
+            if status in ["SYNC_FAILED", "ERROR"]:
+                logger.error(f"Connector {connector_id} sync failed: {error}")
+                return False
+                
+            logger.info(f"Connector {connector_id} status: {status}. Waiting {poll_interval} seconds...")
+            time.sleep(poll_interval)
+        
+        logger.error(f"Timeout waiting for connector {connector_id} sync to complete.")
+        return False
+
+
+def get_client_from_env() -> FivetranAPIClient:
+    """Create a Fivetran API client using environment variables."""
+    api_key = os.environ.get("FIVETRAN_API_KEY")
+    api_secret = os.environ.get("FIVETRAN_API_SECRET")
+    
+    if not api_key or not api_secret:
+        raise ValueError(
+            "FIVETRAN_API_KEY and FIVETRAN_API_SECRET environment variables must be set."
+        )
+    
+    return FivetranAPIClient(api_key, api_secret)
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+    
+    logging.basicConfig(level=logging.INFO)
+    
+    parser = argparse.ArgumentParser(description="Fivetran API Client")
+    parser.add_argument("--list-groups", action="store_true", help="List all groups")
+    parser.add_argument("--list-connectors", help="List all connectors for a group")
+    parser.add_argument("--trigger-sync", help="Trigger a sync for a connector")
+    parser.add_argument("--wait", action="store_true", help="Wait for sync to complete")
+    parser.add_argument("--timeout", type=int, default=3600, help="Timeout in seconds")
+    parser.add_argument("--poll-interval", type=int, default=30, help="Poll interval in seconds")
+    
+    args = parser.parse_args()
+    
+    try:
+        client = get_client_from_env()
+        
+        if args.list_groups:
+            groups = client.get_groups()
+            for group in groups:
+                print(f"Group: {group['name']} (ID: {group['id']})")
+        
+        elif args.list_connectors:
+            connectors = client.get_connectors(args.list_connectors)
+            for connector in connectors:
+                print(f"Connector: {connector['name']} (ID: {connector['id']})")
+                print(f"  Service: {connector['service']}")
+                print(f"  Status: {connector['status']['sync_state']}")
+                print("---")
+        
+        elif args.trigger_sync:
+            print(f"Triggering sync for connector {args.trigger_sync}...")
+            client.trigger_sync(args.trigger_sync)
+            print("Sync triggered.")
+            
+            if args.wait:
+                print(f"Waiting for sync to complete (timeout: {args.timeout}s, poll: {args.poll_interval}s)...")
+                success = client.wait_for_sync_completion(
+                    args.trigger_sync, 
+                    timeout=args.timeout, 
+                    poll_interval=args.poll_interval
+                )
+                if success:
+                    print("Sync completed successfully.")
+                    sys.exit(0)
+                else:
+                    print("Sync failed.")
+                    sys.exit(1)
+        
+        else:
+            parser.print_help()
+    
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_fivetran_api_client.py
+++ b/tests/test_fivetran_api_client.py
@@ -1,0 +1,329 @@
+import os
+import pytest
+import responses
+from unittest.mock import patch
+from src.fivetran_api_client import FivetranAPIClient, get_client_from_env
+
+@pytest.fixture
+def fivetran_client():
+    return FivetranAPIClient("test_api_key", "test_api_secret")
+
+@responses.activate
+def test_get_groups(fivetran_client):
+    # Mock the API response
+    responses.add(
+        responses.GET,
+        "https://api.fivetran.com/v1/groups",
+        json={
+            "code": "Success",
+            "data": {
+                "items": [
+                    {"id": "group1", "name": "Test Group 1"},
+                    {"id": "group2", "name": "Test Group 2"}
+                ]
+            }
+        },
+        status=200
+    )
+    
+    # Call the method
+    groups = fivetran_client.get_groups()
+    
+    # Verify the response
+    assert len(groups) == 2
+    assert groups[0]["id"] == "group1"
+    assert groups[0]["name"] == "Test Group 1"
+    assert groups[1]["id"] == "group2"
+    assert groups[1]["name"] == "Test Group 2"
+
+@responses.activate
+def test_get_connectors(fivetran_client):
+    group_id = "test_group"
+    
+    # Mock the API response
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/groups/{group_id}/connectors",
+        json={
+            "code": "Success",
+            "data": {
+                "items": [
+                    {"id": "conn1", "name": "Connector 1", "service": "klaviyo", "status": {"sync_state": "SYNC_SUCCEEDED"}},
+                    {"id": "conn2", "name": "Connector 2", "service": "postgres", "status": {"sync_state": "SYNCING"}}
+                ]
+            }
+        },
+        status=200
+    )
+    
+    # Call the method
+    connectors = fivetran_client.get_connectors(group_id)
+    
+    # Verify the response
+    assert len(connectors) == 2
+    assert connectors[0]["id"] == "conn1"
+    assert connectors[0]["name"] == "Connector 1"
+    assert connectors[0]["service"] == "klaviyo"
+    assert connectors[0]["status"]["sync_state"] == "SYNC_SUCCEEDED"
+
+@responses.activate
+def test_get_connector(fivetran_client):
+    connector_id = "test_connector"
+    
+    # Mock the API response
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "service": "klaviyo",
+                "status": {
+                    "sync_state": "SYNC_SUCCEEDED",
+                    "update_state": "READY"
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Call the method
+    connector = fivetran_client.get_connector(connector_id)
+    
+    # Verify the response
+    assert connector["id"] == connector_id
+    assert connector["name"] == "Test Connector"
+    assert connector["service"] == "klaviyo"
+    assert connector["status"]["sync_state"] == "SYNC_SUCCEEDED"
+
+@responses.activate
+def test_trigger_sync(fivetran_client):
+    connector_id = "test_connector"
+    
+    # Mock the API response
+    responses.add(
+        responses.POST,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}/sync",
+        json={
+            "code": "Success",
+            "message": "Sync started"
+        },
+        status=200
+    )
+    
+    # Call the method
+    response = fivetran_client.trigger_sync(connector_id)
+    
+    # Verify the response
+    assert response["code"] == "Success"
+    assert response["message"] == "Sync started"
+
+@responses.activate
+def test_get_sync_status(fivetran_client):
+    connector_id = "test_connector"
+    
+    # Mock the API response
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "status": {
+                    "sync_state": "SYNCING",
+                    "sync_error": None
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Call the method
+    status, error = fivetran_client.get_sync_status(connector_id)
+    
+    # Verify the response
+    assert status == "SYNCING"
+    assert error is None
+
+@responses.activate
+def test_get_sync_status_with_error(fivetran_client):
+    connector_id = "test_connector"
+    
+    # Mock the API response
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "status": {
+                    "sync_state": "SYNC_FAILED",
+                    "sync_error": "API authentication failed"
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Call the method
+    status, error = fivetran_client.get_sync_status(connector_id)
+    
+    # Verify the response
+    assert status == "SYNC_FAILED"
+    assert error == "API authentication failed"
+
+@responses.activate
+def test_wait_for_sync_completion_success(fivetran_client):
+    connector_id = "test_connector"
+    
+    # Mock the API response for the first call (SYNCING)
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "status": {
+                    "sync_state": "SYNCING",
+                    "sync_error": None
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Mock the API response for the second call (SYNC_SUCCEEDED)
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "status": {
+                    "sync_state": "SYNC_SUCCEEDED",
+                    "sync_error": None
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Call the method with a short poll interval
+    with patch('time.sleep') as mock_sleep:  # Mock sleep to speed up the test
+        result = fivetran_client.wait_for_sync_completion(connector_id, poll_interval=1)
+    
+    # Verify the result
+    assert result is True
+    assert mock_sleep.call_count == 1  # Should sleep once between the two API calls
+
+@responses.activate
+def test_wait_for_sync_completion_failure(fivetran_client):
+    connector_id = "test_connector"
+    
+    # Mock the API response for the first call (SYNCING)
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "status": {
+                    "sync_state": "SYNCING",
+                    "sync_error": None
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Mock the API response for the second call (SYNC_FAILED)
+    responses.add(
+        responses.GET,
+        f"https://api.fivetran.com/v1/connectors/{connector_id}",
+        json={
+            "code": "Success",
+            "data": {
+                "id": connector_id,
+                "name": "Test Connector",
+                "status": {
+                    "sync_state": "SYNC_FAILED",
+                    "sync_error": "API authentication failed"
+                }
+            }
+        },
+        status=200
+    )
+    
+    # Call the method with a short poll interval
+    with patch('time.sleep') as mock_sleep:  # Mock sleep to speed up the test
+        result = fivetran_client.wait_for_sync_completion(connector_id, poll_interval=1)
+    
+    # Verify the result
+    assert result is False
+    assert mock_sleep.call_count == 1  # Should sleep once between the two API calls
+
+@responses.activate
+def test_rate_limit_handling(fivetran_client):
+    # Mock the API response with a rate limit error
+    responses.add(
+        responses.GET,
+        "https://api.fivetran.com/v1/groups",
+        status=429,
+        headers={"Retry-After": "1"}  # 1 second retry
+    )
+    
+    # Mock the API response for the retry
+    responses.add(
+        responses.GET,
+        "https://api.fivetran.com/v1/groups",
+        json={
+            "code": "Success",
+            "data": {
+                "items": [
+                    {"id": "group1", "name": "Test Group 1"}
+                ]
+            }
+        },
+        status=200
+    )
+    
+    # Call the method
+    with patch('time.sleep') as mock_sleep:  # Mock sleep to speed up the test
+        groups = fivetran_client.get_groups()
+    
+    # Verify the response
+    assert len(groups) == 1
+    assert groups[0]["id"] == "group1"
+    assert groups[0]["name"] == "Test Group 1"
+    assert mock_sleep.call_count == 1  # Should sleep once for the rate limit
+
+def test_get_client_from_env():
+    # Mock environment variables
+    with patch.dict(os.environ, {
+        "FIVETRAN_API_KEY": "test_key",
+        "FIVETRAN_API_SECRET": "test_secret"
+    }):
+        client = get_client_from_env()
+        assert client.api_key == "test_key"
+        assert client.api_secret == "test_secret"
+
+def test_get_client_from_env_missing_vars():
+    # Mock environment variables (missing API secret)
+    with patch.dict(os.environ, {
+        "FIVETRAN_API_KEY": "test_key"
+    }, clear=True):
+        with pytest.raises(ValueError) as excinfo:
+            get_client_from_env()
+        assert "FIVETRAN_API_KEY and FIVETRAN_API_SECRET environment variables must be set" in str(excinfo.value)


### PR DESCRIPTION
Implements PR #13 from the [Fivetran + BigQuery Integration PR Plan](docs/FIVETRAN_BIGQUERY_PR_PLAN.md).

This PR adds the fivetran_api_client.py script for interacting with the Fivetran API.

## Changes
- Thin wrapper around Fivetran REST API (/groups, /connectors, /connectors/:id/sync)
- Helper to trigger a manual sync & poll status until SUCCESS or FAILURE
- Basic rate-limit back-off handling
- Unit tests with mocked HTTP responses (using responses)

## Validation
- [x] pytest tests/test_fivetran_api_client.py passes
- [x] Implemented correct endpoint paths & error handling

## Checklist
- [x] All validation steps passed
- [x] Code follows project style guidelines
- [x] Unit tests cover key functionality