### PR TITLE
PR 17: S3 Uploader Utility

### DIFF
--- a/src/s3_uploader.py
+++ b/src/s3_uploader.py
@@ -1,0 +1,132 @@
+import os
+import logging
+import boto3
+from botocore.exceptions import ClientError
+from botocore.config import Config
+
+logger = logging.getLogger(__name__)
+
+def validate_s3_env_vars():
+    required_vars = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"]
+    missing_vars = [var for var in required_vars if not os.environ.get(var)]
+    
+    if missing_vars:
+        raise ValueError(
+            f"Missing required AWS S3 environment variables: {', '.join(missing_vars)}"
+        )
+
+def get_s3_client():
+    validate_s3_env_vars()
+    
+    # Configure retry behavior with exponential backoff
+    config = Config(
+        retries={
+            'max_attempts': 5,
+            'mode': 'adaptive'
+        }
+    )
+    
+    return boto3.client(
+        's3',
+        region_name=os.environ.get('AWS_REGION'),
+        aws_access_key_id=os.environ.get('AWS_ACCESS_KEY_ID'),
+        aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
+        config=config
+    )
+
+def upload_file(local_path, bucket, key, metadata=None, content_type=None):
+    """
+    Upload a file to an S3 bucket with exponential backoff retry logic
+    
+    Args:
+        local_path (str): Path to the local file to upload
+        bucket (str): S3 bucket name
+        key (str): S3 object key (path within bucket)
+        metadata (dict, optional): Metadata to attach to the S3 object
+        content_type (str, optional): Content type of the file
+        
+    Returns:
+        str: The URL of the uploaded file if successful, None otherwise
+    """
+    if not os.path.exists(local_path):
+        raise FileNotFoundError(f"Local file not found: {local_path}")
+    
+    try:
+        s3_client = get_s3_client()
+        
+        # Prepare upload parameters
+        upload_args = {
+            'Bucket': bucket,
+            'Key': key,
+            'Body': open(local_path, 'rb')
+        }
+        
+        if metadata:
+            upload_args['Metadata'] = metadata
+            
+        if content_type:
+            upload_args['ContentType'] = content_type
+        
+        # Perform the upload
+        s3_client.upload_file(
+            local_path,
+            bucket,
+            key,
+            ExtraArgs={
+                'Metadata': metadata or {},
+                'ContentType': content_type or 'application/octet-stream'
+            }
+        )
+        
+        logger.info(f"Successfully uploaded {local_path} to s3://{bucket}/{key}")
+        return f"s3://{bucket}/{key}"
+    
+    except ClientError as e:
+        logger.error(f"S3 upload error: {e}")
+        raise
+
+def main():
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Upload a file to S3")
+    parser.add_argument("local_path", help="Path to the local file to upload")
+    parser.add_argument("bucket", help="S3 bucket name")
+    parser.add_argument("key", help="S3 object key (path within bucket)")
+    parser.add_argument("--content-type", help="Content type of the file")
+    parser.add_argument("--metadata", help="Metadata as key=value pairs, comma-separated")
+    parser.add_argument("--dry-run", action="store_true", help="Don't actually upload, just validate and log")
+    
+    args = parser.parse_args()
+    
+    # Parse metadata if provided
+    metadata = {}
+    if args.metadata:
+        for pair in args.metadata.split(","):
+            if "=" in pair:
+                key, value = pair.split("=", 1)
+                metadata[key.strip()] = value.strip()
+    
+    if args.dry_run:
+        print(f"DRY RUN: Would upload {args.local_path} to s3://{args.bucket}/{args.key}")
+        if args.content_type:
+            print(f"Content-Type: {args.content_type}")
+        if metadata:
+            print(f"Metadata: {metadata}")
+        return
+    
+    try:
+        result = upload_file(
+            args.local_path,
+            args.bucket,
+            args.key,
+            metadata=metadata,
+            content_type=args.content_type
+        )
+        print(f"Successfully uploaded to {result}")
+    except Exception as e:
+        print(f"Error: {e}")
+        exit(1)
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/tests/test_s3_uploader.py
+++ b/tests/test_s3_uploader.py
@@ -1,0 +1,155 @@
+import os
+import pytest
+import tempfile
+from unittest.mock import patch, MagicMock
+from botocore.exceptions import ClientError
+
+import boto3
+from moto import mock_aws
+
+from src.s3_uploader import validate_s3_env_vars, get_s3_client, upload_file
+
+
+def test_validate_s3_env_vars_success():
+    # Test with all required environment variables set
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test_key",
+        "AWS_SECRET_ACCESS_KEY": "test_secret",
+        "AWS_REGION": "us-east-1"
+    }):
+        # This should not raise an exception
+        validate_s3_env_vars()
+
+
+def test_validate_s3_env_vars_missing():
+    # Test with missing environment variables
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test_key"
+        # Missing AWS_SECRET_ACCESS_KEY and AWS_REGION
+    }, clear=True):
+        with pytest.raises(ValueError) as excinfo:
+            validate_s3_env_vars()
+        assert "Missing required AWS S3 environment variables" in str(excinfo.value)
+        assert "AWS_SECRET_ACCESS_KEY" in str(excinfo.value)
+        assert "AWS_REGION" in str(excinfo.value)
+
+
+def test_get_s3_client():
+    # Test that the client is created with the correct configuration
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test_key",
+        "AWS_SECRET_ACCESS_KEY": "test_secret",
+        "AWS_REGION": "us-east-1"
+    }):
+        with patch("boto3.client") as mock_client:
+            get_s3_client()
+            # Check that boto3.client was called with the correct arguments
+            mock_client.assert_called_once()
+            args, kwargs = mock_client.call_args
+            assert args[0] == 's3'
+            assert kwargs['region_name'] == "us-east-1"
+            assert kwargs['aws_access_key_id'] == "test_key"
+            assert kwargs['aws_secret_access_key'] == "test_secret"
+            assert 'config' in kwargs  # Just check that config is present
+
+
+@mock_aws
+def test_upload_file_success():
+    # Set up environment variables
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test_key",
+        "AWS_SECRET_ACCESS_KEY": "test_secret",
+        "AWS_REGION": "us-east-1"
+    }):
+        # Create a temporary file to upload
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(b"Test content")
+            temp_file_path = temp_file.name
+        
+        try:
+            # Create a test bucket
+            s3_client = boto3.client(
+                's3',
+                region_name="us-east-1",
+                aws_access_key_id="test_key",
+                aws_secret_access_key="test_secret"
+            )
+            bucket_name = "test-bucket"
+            s3_client.create_bucket(Bucket=bucket_name)
+            
+            # Test uploading the file
+            key = "test-folder/test-file.txt"
+            metadata = {"test-key": "test-value"}
+            content_type = "text/plain"
+            
+            result = upload_file(
+                temp_file_path,
+                bucket_name,
+                key,
+                metadata=metadata,
+                content_type=content_type
+            )
+            
+            # Verify the result
+            assert result == f"s3://{bucket_name}/{key}"
+            
+            # Verify the file was uploaded correctly
+            response = s3_client.get_object(Bucket=bucket_name, Key=key)
+            assert response["ContentType"] == content_type
+            assert response["Metadata"] == metadata
+            assert response["Body"].read() == b"Test content"
+        
+        finally:
+            # Clean up the temporary file
+            os.unlink(temp_file_path)
+
+
+def test_upload_file_file_not_found():
+    # Test uploading a non-existent file
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test_key",
+        "AWS_SECRET_ACCESS_KEY": "test_secret",
+        "AWS_REGION": "us-east-1"
+    }):
+        with pytest.raises(FileNotFoundError):
+            upload_file(
+                "/path/to/nonexistent/file.txt",
+                "test-bucket",
+                "test-key"
+            )
+
+
+def test_upload_file_client_error():
+    # Test handling of ClientError
+    with patch.dict(os.environ, {
+        "AWS_ACCESS_KEY_ID": "test_key",
+        "AWS_SECRET_ACCESS_KEY": "test_secret",
+        "AWS_REGION": "us-east-1"
+    }):
+        # Create a temporary file to upload
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            temp_file.write(b"Test content")
+            temp_file_path = temp_file.name
+        
+        try:
+            # Mock the S3 client to raise an exception
+            mock_client = MagicMock()
+            mock_client.upload_file.side_effect = ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+                "UploadFile"
+            )
+            
+            with patch("src.s3_uploader.get_s3_client", return_value=mock_client):
+                with pytest.raises(ClientError) as excinfo:
+                    upload_file(
+                        temp_file_path,
+                        "test-bucket",
+                        "test-key"
+                    )
+                
+                assert "AccessDenied" in str(excinfo.value)
+                assert "Access Denied" in str(excinfo.value)
+        
+        finally:
+            # Clean up the temporary file
+            os.unlink(temp_file_path)


### PR DESCRIPTION
Implements PR #17 from the [Fivetran + BigQuery Integration PR Plan](docs/FIVETRAN_BIGQUERY_PR_PLAN.md).

This PR adds the s3_uploader.py script for uploading files to S3 with retry logic.

## Changes
- Add src/s3_uploader.py
  * Function upload_file(local_path, bucket, key) with metadata and content-type support
  * Uses boto3 with exponential backoff retry logic
  * Includes CLI interface for direct usage
- Add moto-mocked tests in tests/test_s3_uploader.py

## Validation
- [x] Moto tests pass
- [x] Upload errors raise clear exceptions

## Merge Checklist
- [x] All validation steps passed
- [x] Code follows project style guidelines
- [x] Unit tests cover key functionality