### PR TITLE
PR 31: Remove flow table from smoke test requirements

### DIFF
--- a/scripts/bq_sanity_check.py
+++ b/scripts/bq_sanity_check.py
@@ -47,7 +47,7 @@ def get_table_list() -> List[str]:
         return args.tables.split(",")
     elif tables_env:
         return tables_env.split(",")
-    return ["campaign", "event", "flow", "list"]
+    return ["campaign", "event", "list"]
 
 
 def check_table(client: bigquery.Client, project_id: str, dataset_id: str, 

--- a/scripts/run_end_to_end_demo.sh
+++ b/scripts/run_end_to_end_demo.sh
@@ -321,7 +321,7 @@ if [ "$SKIP_BIGQUERY" = false ]; then
         log "[DRY RUN] Would load to BigQuery: $BQ_CMD"
         
         # Get tables to check from environment or use default
-        SANITY_TABLES=${E2E_SANITY_TABLES:-"campaign,event,flow,list"}
+        SANITY_TABLES=${E2E_SANITY_TABLES:-"campaign,event,list"}
         
         # Show what would be run in dry-run mode
         SANITY_CMD="python $SCRIPT_DIR/bq_sanity_check.py --env $ROOT_DIR/.env --tables $SANITY_TABLES --dry-run"
@@ -341,7 +341,7 @@ if [ "$SKIP_BIGQUERY" = false ]; then
         # Run BigQuery sanity check after successful load
         log "Running BigQuery sanity check"
         # Get tables to check from environment or use default
-        SANITY_TABLES=${E2E_SANITY_TABLES:-"campaign,event,flow,list"}
+        SANITY_TABLES=${E2E_SANITY_TABLES:-"campaign,event,list"}
         
         SANITY_CMD="python $SCRIPT_DIR/bq_sanity_check.py --env $ROOT_DIR/.env --tables $SANITY_TABLES"
         log "Running BigQuery sanity check: $SANITY_CMD"

--- a/tests/test_bq_sanity_check.py
+++ b/tests/test_bq_sanity_check.py
@@ -59,7 +59,7 @@ class TestBQSanityCheck(unittest.TestCase):
         bq_sanity_check.args.tables = ""
         
         tables = bq_sanity_check.get_table_list()
-        self.assertEqual(tables, ["campaign", "event", "flow", "list"])
+        self.assertEqual(tables, ["campaign", "event", "list"])
     
     def test_check_table_exists(self):
         # Create a direct mock for the client

--- a/tests/test_e2e_sanity_integration.py
+++ b/tests/test_e2e_sanity_integration.py
@@ -72,7 +72,7 @@ class TestE2ESanityIntegration(unittest.TestCase):
         self.assertEqual(result.returncode, 0, f"Script failed with output: {result.stderr}")
         
         # Check that the output contains the default tables
-        self.assertIn("campaign,event,flow,list", result.stdout)
+        self.assertIn("campaign,event,list", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This PR implements the changes described in PR 31 of the [FIX_REPORTING_VIEW_AND_DEPLOY_PR_PLAN.md](docs/FIX_REPORTING_VIEW_AND_DEPLOY_PR_PLAN.md) document. It removes the 'flow' table from the required tables list in the smoke test to prevent failures when the flow table is not available.

## Changes Made

- Modified 'scripts/bq_sanity_check.py' to remove 'flow' from the default table list
- Updated 'scripts/run_end_to_end_demo.sh' to remove 'flow' from the default SANITY_TABLES value in both occurrences
- Updated tests in 'tests/test_bq_sanity_check.py' and 'tests/test_e2e_sanity_integration.py' to reflect the new default table list

## Validation

- Ran tests for 'bq_sanity_check.py' which passed successfully
- Note: The e2e integration tests are failing due to environment setup issues, not because of our code changes

## Related Issues

This PR addresses the optional item in the FIX_REPORTING_VIEW_AND_DEPLOY_PR_PLAN.md document to remove the flow table from smoke test requirements.